### PR TITLE
Implement retry for aws s3 sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,8 @@ $ docker image pull dceoy/s3-sync-entrypoint
     2.  Execute the command (`cp -r /input/input0 /input/input1 /output/`).
     3.  Recursively copy `/output` (`OUTPUT_DATA_DIR`) to `s3://bucket-o/output0`.
 
+    Each `aws s3 sync` is retried up to 3 total attempts by default. Use
+    `--sync-retry-attempts` and `--sync-retry-interval` to adjust the retry
+    behavior.
+
 Run `s3-sync-entrypoint --help` for more information.

--- a/s3-sync-entrypoint
+++ b/s3-sync-entrypoint
@@ -7,6 +7,7 @@
 #   s3-sync-entrypoint [--debug] [--dryrun] (--input-s3=<uri>)...
 #       [--intermediate-s3=<uri>] [--output-s3=<uri>]
 #       (--inbound-sync-option=<arg>)... (--outbound-sync-option=<arg>)...
+#       [--sync-retry-attempts=<count>] [--sync-retry-interval=<seconds>]
 #       [--input-data-dir=<path>] [--output-data-dir=<path>]
 #       [--intermediate-data-dir=<path>] [--upload-log-to-s3=<uri>]
 #       [--wait-for-volume-mount=<path>] [--volume-mount-timeout=<seconds>]
@@ -30,6 +31,12 @@
 #                       (e.g., --inbound-sync-option='--exclude="*.zip"')
 #   --outbound-sync-option=<arg>
 #                       Specify an option of `aws s3 sync` for outbound sync
+#   --sync-retry-attempts=<count>
+#                       Retry `aws s3 sync` up to the specified total attempts
+#                       (default: 3)
+#   --sync-retry-interval=<seconds>
+#                       Wait time in seconds before retrying `aws s3 sync`
+#                       (default: 5)
 #   --input-data-dir=<path>
 #                       Specify a local directory path for input data from S3
 #                       (This overrides `${INPUT_DATA_DIR}`.)
@@ -72,7 +79,7 @@ set -u
 ARGV=("${*}")
 SSE_SCRIPT_PATH=$(realpath "${0}")
 SSE_SCRIPT_NAME=$(basename "${SSE_SCRIPT_PATH}")
-SSE_SCRIPT_VERSION='v0.3.0'
+SSE_SCRIPT_VERSION='v0.4.0'
 SSE_DRYRUN=0
 SSE_SKIP_OUTPUT_ON_ERROR=0
 SSE_INPUT_S3_URIS=()
@@ -89,6 +96,8 @@ SSE_DISABLE_LOOKUP=0
 SSE_VOLUME_MOUNT_PATH=''
 SSE_VOLUME_MOUNT_TIMEOUT=300
 SSE_VOLUME_MOUNT_INTERVAL=5
+SSE_SYNC_RETRY_ATTEMPTS=3
+SSE_SYNC_RETRY_INTERVAL=5
 for a in "${@}"; do
   [[ "${a}" = '--disable-lookup' ]] && SSE_DISABLE_LOOKUP=1 && break
 done
@@ -173,6 +182,27 @@ function wait_for_volume_mount {
   fi
 }
 
+function sync_s3_with_retry {
+  local sync_command="${1}"
+  local attempt=1
+  local exit_code=0
+  while [[ ${attempt} -le ${SSE_SYNC_RETRY_ATTEMPTS} ]]; do
+    if echo_n_eval "${sync_command}"; then
+      return 0
+    else
+      exit_code="${?}"
+    fi
+    if [[ ${attempt} -ge ${SSE_SYNC_RETRY_ATTEMPTS} ]]; then
+      break
+    fi
+    echo_n_log \
+      "aws s3 sync failed with exit code ${exit_code}; retrying in ${SSE_SYNC_RETRY_INTERVAL}s (attempt $((attempt + 1))/${SSE_SYNC_RETRY_ATTEMPTS})"
+    sleep "${SSE_SYNC_RETRY_INTERVAL}"
+    attempt=$((attempt + 1))
+  done
+  return "${exit_code}"
+}
+
 while [[ ${#} -ge 1 ]]; do
   {
     case "${1}" in
@@ -223,6 +253,18 @@ while [[ ${#} -ge 1 ]]; do
         ;;
       --outbound-sync-option=* )
         SSE_OUTBOUND_SYNC_OPTIONS+=("$(read_str "${1#*\=}")") && shift 1
+        ;;
+      --sync-retry-attempts )
+        SSE_SYNC_RETRY_ATTEMPTS="$(read_str "${2}")" && shift 2
+        ;;
+      --sync-retry-attempts=* )
+        SSE_SYNC_RETRY_ATTEMPTS="$(read_str "${1#*\=}")" && shift 1
+        ;;
+      --sync-retry-interval )
+        SSE_SYNC_RETRY_INTERVAL="$(read_str "${2}")" && shift 2
+        ;;
+      --sync-retry-interval=* )
+        SSE_SYNC_RETRY_INTERVAL="$(read_str "${1#*\=}")" && shift 1
         ;;
       --input-data-dir )
         INPUT_DATA_DIR="$(read_str "${2}")" && shift 2
@@ -276,6 +318,12 @@ while [[ ${#} -ge 1 ]]; do
     } || exit 1
 done
 
+if ! [[ "${SSE_SYNC_RETRY_ATTEMPTS}" =~ ^[0-9]+$ ]] || [[ "${SSE_SYNC_RETRY_ATTEMPTS}" -le 0 ]]; then
+  abort "invalid sync retry attempts: ${SSE_SYNC_RETRY_ATTEMPTS}"
+elif ! [[ "${SSE_SYNC_RETRY_INTERVAL}" =~ ^[0-9]+$ ]]; then
+  abort "invalid sync retry interval: ${SSE_SYNC_RETRY_INTERVAL}"
+fi
+
 [[ -n "${SSE_OUTPUT_LOG_S3_URI}" ]] && echo -ne > "${SSE_OUTPUT_LOG_FILE}"
 
 echo_n_log "ARGV:                   ${ARGV[*]}"
@@ -328,6 +376,11 @@ if [[ -n "${SSE_OUTPUT_LOG_S3_URI}" ]]; then
   validate_s3_uri "${SSE_OUTPUT_LOG_S3_URI}"
 fi
 
+if [[ ${#SSE_INPUT_S3_URIS[@]} -gt 0 ]] || [[ -n "${SSE_INTERMEDIATE_S3_URI}" ]] || [[ -n "${SSE_OUTPUT_S3_URI}" ]]; then
+  echo_n_log "SYNC_RETRY_ATTEMPTS:    ${SSE_SYNC_RETRY_ATTEMPTS}"
+  echo_n_log "SYNC_RETRY_INTERVAL:    ${SSE_SYNC_RETRY_INTERVAL}"
+fi
+
 if [[ -n "${SSE_VOLUME_MOUNT_PATH}" ]]; then
   echo_n_log "VOLUME_MOUNT_PATH:      ${SSE_VOLUME_MOUNT_PATH}"
   echo_n_log "VOLUME_MOUNT_TIMEOUT:   ${SSE_VOLUME_MOUNT_TIMEOUT}"
@@ -351,12 +404,12 @@ fi
 
 if [[ ${#SSE_INPUT_S3_URIS[@]} -gt 0 ]]; then
   for i in "${SSE_INPUT_S3_URIS[@]}"; do
-    echo_n_eval "aws s3 ${SSE_INBOUND_SYNC} ${i} ${INPUT_DATA_DIR%/}/"
+    sync_s3_with_retry "aws s3 ${SSE_INBOUND_SYNC} ${i} ${INPUT_DATA_DIR%/}/"
   done
 fi
 
 if [[ -n "${SSE_INTERMEDIATE_S3_URI}" ]]; then
-  echo_n_eval \
+  sync_s3_with_retry \
     "aws s3 ${SSE_INBOUND_SYNC} ${SSE_INTERMEDIATE_S3_URI} ${SSE_INTERMEDIATE_DATA_DIR%/}/"
 fi
 
@@ -369,7 +422,7 @@ if [[ -n "${SSE_OUTPUT_S3_URI}" ]]; then
   if [[ ${SSE_SKIP_OUTPUT_ON_ERROR} -ne 0 ]] && [[ ${SSE_COMMAND_EXIT_CODE} -ne 0 ]]; then
     echo -e 'The outbound sync was skipped due to the exit code.'
   else
-    echo_n_eval "aws s3 ${SSE_OUTBOUND_SYNC} ${OUTPUT_DATA_DIR%/}/ ${SSE_OUTPUT_S3_URI}"
+    sync_s3_with_retry "aws s3 ${SSE_OUTBOUND_SYNC} ${OUTPUT_DATA_DIR%/}/ ${SSE_OUTPUT_S3_URI}"
     validate_s3_uri "${SSE_OUTPUT_S3_URI}"
   fi
 fi


### PR DESCRIPTION
## Summary
- add retry handling around inbound, intermediate, and outbound `aws s3 sync`
- add `--sync-retry-attempts` and `--sync-retry-interval` options
- document the retry behavior in the script help and README

## Validation
- `bash -n ./s3-sync-entrypoint`
- `./s3-sync-entrypoint --version`
- `./s3-sync-entrypoint --help`
- mocked `aws s3 sync` retry flow with transient and persistent failures